### PR TITLE
register preferences on session

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,10 @@ class PagesController < ApplicationController
   end
 
   def submit_preferences
-    current_user.menus.destroy_all
+    if user_signed_in?
+      current_user.menus.destroy_all
+    end
+    
     preferences = session["preferences"]
     params["preferences"].each do |key, value|
       if preferences.key?(key)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,6 @@
       <%= render  "shared/navbar" %>
     <% end %>
     <%= render 'shared/flashes' %>
-    <%= yield %>
+    <%= yield %>    
   </body>
 </html>


### PR DESCRIPTION
Hello !

I noticed that we didn't save the user's preferences on its session anymore (there was a regression).
I fixed it by adding a condition before executing the current_user.menu.destro_all

